### PR TITLE
set minimum compatibility to stable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,6 @@
             "dev-master": "1.0-dev"
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }


### PR DESCRIPTION
Added minimum stability flag to be stable because `dev-master` is never a good idea. Now users can just install using `composer require malhal/laravel-createdby`.
